### PR TITLE
chore: use our private Nix cache for Docker image pushes

### DIFF
--- a/.github/workflows/push-to-ghcr.yaml
+++ b/.github/workflows/push-to-ghcr.yaml
@@ -26,12 +26,30 @@ jobs:
           # Required by flakes
           fetch-depth: 0
 
+      - name: Import secrets from Vault
+        uses: hashicorp/vault-action@v2.7.3
+        id: secrets
+        with:
+          url: https://vault.hackworth-corp.com
+          path: "github-actions"
+          role: nix-buildkite-push-docker-image
+          method: jwt
+          secrets: |
+            secret/data/cachix/hackworthltd-private/github-workflows token | CACHIX_AUTH_TOKEN ;
+
       - name: Install & configure Nix
         uses: cachix/install-nix-action@v22
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hackworthltd.cachix.org-1:0JTCI0qDo2J+tonOalrSQP3yRNleN6bQucJ05yDltRI= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             substituters = https://cache.nixos.org?priority=10 https://hackworthltd.cachix.org?priority=30 https://cache.iog.io?priority=40
+
+      - name: Configure Cachix for private Hackworth Ltd cache
+        uses: cachix/cachix-action@v12
+        with:
+          name: hackworthltd-private
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
 
         # Note: if this Nix derivation hasn't been built yet, it will
         # kick off a Nix build on a GitHub runner, which isn't ideal.


### PR DESCRIPTION
This is a public repo, but for technical reasons, our CI system only pushes PR build artifacts to our private Nix cache. When the ghcr.io Docker image push job runs in GitHub Actions, on merges to `main`, we want to be sure that job doesn't rebuild anything from scratch, so we need to give this job access to our private Nix cache.

Note that a future commit will push Nix build artifacts to our public Nix cache on merges to `main`, but it won't fix this particular issue, because that public cache push job and the Docker image push job will run simultaneously.