### PR TITLE
feat: add support for Buildkite agent-stack-k8s pipelines

### DIFF
--- a/nix-buildkite-plugin.cabal
+++ b/nix-buildkite-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               nix-buildkite-plugin
-version:            0.2.0.0
+version:            0.3.0.0
 license-file:       LICENSE
 author:             Hackworth Ltd <src@hackworthltd.com>
 maintainer:         src@hackworthltd.com


### PR DESCRIPTION
This mode is set by setting the environment variable `PIPELINE_TYPE`
to `kubernetes`. The container image used in the pipeline is set by
the `KUBERNETES_CONTAINER_IMAGE` environment variable, and is
`nixos/nix:latest` by default.

Signed-off-by: Drew Hess <src@drewhess.com>
