### PR TITLE
feat: use `nix-eval-jobs` to evaluate Nix expressions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,8 +12,10 @@ steps:
       env:
           BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH: "true"
       plugins:
-          - hackworthltd/nix#v1.1.2:
-                expr: jobs.nix
+          - hackworthltd/nix#v2.0.0-b1:
+                expr: ".#hydraJobs.required"
+                nix-eval-jobs-args: --workers 8 --max-memory-size 32GiB --flake --constituents
+                jq-filter: .drvPath, .constituents[]
                 agent-tags: queue=nix-build,os=linux
 
     - wait

--- a/README.md
+++ b/README.md
@@ -8,50 +8,42 @@ topological ordering that will ensure steps have the correct
 dependencies between them.
 
 Note: this project is a fork of [Circuithub's
-`nix-buildkite-buildkite-plugin``](https://github.com/circuithub/nix-buildkite-buildkite-plugin),
+`nix-buildkite-buildkite-plugin`](https://github.com/circuithub/nix-buildkite-buildkite-plugin),
 and we would like to thank them for their work, without which this
 project wouldn't be possible!
 
-# Getting Started
+# Usage
 
-## `jobs.nix`
-
-First, create a `jobs.nix` file in your repository. This file will contain a
-tree of all builds that you are interested in. We create this tree using nested
-attrsets that eventually have leaves that are derivations.
-
-For this example, we'll start by building the `nix-buildkite` project. Our
-`jobs.nix` file is:
-
-```nix
-(import nix/flake-compat.nix).defaultNix.ciJobs
-```
-
-## `.buildkite/pipeline.yml`
-
-Next, add a `.buildkite/pipeline.yml` file with the following contents:
+To use the plugin, add a `.buildkite/pipeline.yml` file to your repo.
+The plugin will use
+[`nix-eval-jobs`](https://github.com/nix-community/nix-eval-jobs) to
+evaluate the given expression and generate a list of derivations to
+build. For example, here we use a file named `jobs.nix` which, when
+evaluated, will produce a list of derivations:
 
 ```yaml
 steps:
   - command: nix-buildkite
     label: ":nixos: :buildkite:"
     plugins:
-      - hackworthltd/nix#v1.0.0:
-          file: jobs.nix
+      - hackworthltd/nix#v2.0.0:
+          expr: jobs.nix
 ```
 
-## Add Your Pipeline
+Next, configure your Buildkite pipeline to upload the dynamic pipeline
+created by the plugin when builds are triggered on your repo. See
+https://buildkite.com/docs/pipelines/defining-steps#getting-started
+for details on how to do this.
 
-The final step is to add your pipeline to Buildkite. See
-https://buildkite.com/docs/pipelines/defining-steps#getting-started for details
-on how to do this. Once you have a pipeline created, make sure that the only
-step declared in the pipeline configuration in Buildkite's UI is:
+Your static Buildkite pipeline should look something like this:
 
 ```yaml
 steps:
   - command: buildkite-agent pipeline upload
     label: ":pipeline:"
 ```
+
+# Plugin options
 
 ## Post-build hooks
 
@@ -65,8 +57,8 @@ steps:
   - command: nix-buildkite
     label: ":nixos: :buildkite:"
     plugins:
-      - hackworthltd/nix#v1.0.0:
-          file: jobs.nix
+      - hackworthltd/nix#v2.0.0:
+          expr: jobs.nix
           post-build-hook: /etc/nix/upload-to-cache.sh
 ```
 
@@ -82,8 +74,3 @@ different pipelines' outputs to different binary caches.
 Note that in order to use this feature, you'll need to add the user
 that the Buildkite agent runs as to `nix.trustedUsers`, as only
 trusted users can run post-build hooks.
-
-## Sit Back and Enjoy!
-
-That's it! Following these steps should give you a working pipeline that builds
-`nix-buildkite`.

--- a/flake.lock
+++ b/flake.lock
@@ -232,6 +232,27 @@
         "type": "github"
       }
     },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-eval-jobs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -730,6 +751,23 @@
         "type": "github"
       }
     },
+    "nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752054614,
+        "narHash": "sha256-GMLWJVc1nyRf5FA+qn2D/jEjCf8lXJpkFRTYyKiKte4=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "ed8f7df56d49d19a80ff0566cd8c80db752669ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.30-maintenance",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -748,6 +786,27 @@
       "original": {
         "owner": "LnL7",
         "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nix-eval-jobs": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "nix": "nix",
+        "nixpkgs": "nixpkgs_2",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1752683968,
+        "narHash": "sha256-urOFgqXzs+cgd1CKFuN245vOeVx7rIldlS9Q5WcemCw=",
+        "owner": "nix-community",
+        "repo": "nix-eval-jobs",
+        "rev": "a579b1a416dc04d50c0dc2832e9da24b0d08dbac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-eval-jobs",
         "type": "github"
       }
     },
@@ -930,6 +989,21 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1752066716,
+        "narHash": "sha256-vMs55uRO/FmzFMWwVtXSnP1dxPC9u9M9I5jNVTqXVFA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "303269b20fe8f5218f8112ff1cbd2a926b75c147",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -1000,12 +1074,13 @@
         "hacknix": "hacknix",
         "haskell-language-server": "haskell-language-server",
         "haskell-nix": "haskell-nix",
+        "nix-eval-jobs": "nix-eval-jobs",
         "nixpkgs": [
           "haskell-nix",
           "nixpkgs-unstable"
         ],
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_2",
-        "treefmt-nix": "treefmt-nix_2"
+        "treefmt-nix": "treefmt-nix_3"
       }
     },
     "stackage": {
@@ -1061,6 +1136,27 @@
       }
     },
     "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-eval-jobs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752055615,
+        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,8 @@
     haskell-language-server.url = "github:haskell/haskell-language-server/748603e1cf4d85b3aa31bff4d91edd4b8b3fa66b";
     cabal-fmt.url = "github:phadej/cabal-fmt";
     cabal-fmt.flake = false;
+
+    nix-eval-jobs.url = "github:nix-community/nix-eval-jobs";
   };
 
   outputs =
@@ -243,6 +245,19 @@
                 };
               };
             };
+
+          with-nix-eval-jobs = pkgs.writeShellApplication {
+            name = "with-nix-eval-jobs";
+            runtimeInputs =
+              (with pkgs; [
+                jq
+              ])
+              ++ [
+                inputs.nix-eval-jobs.packages.${system}.nix-eval-jobs
+                nix-buildkite
+              ];
+            text = builtins.readFile ./scripts/with-nix-eval-jobs.sh;
+          };
         in
         {
           # We need a `pkgs` that includes our own overlays within
@@ -274,6 +289,7 @@
           packages =
             {
               inherit nix-buildkite;
+              inherit with-nix-eval-jobs;
             }
             // (pkgs.lib.optionalAttrs (system == "x86_64-linux") {
               inherit nix-buildkite-docker-image;

--- a/hooks/command
+++ b/hooks/command
@@ -1,16 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -x
 
 NIX_EXPR="$BUILDKITE_PLUGIN_NIX_EXPR"
+
 if [[ -n "${BUILDKITE_PLUGIN_NIX_POST_BUILD_HOOK:-}" ]]; then
     export POST_BUILD_HOOK="$BUILDKITE_PLUGIN_NIX_POST_BUILD_HOOK"
 fi
+
 if [[ -n "${BUILDKITE_PLUGIN_NIX_AGENT_TAGS:-}" ]]; then
     export AGENT_TAGS="$BUILDKITE_PLUGIN_NIX_AGENT_TAGS"
 fi
 
-echo "--- :nixos: Running nix-buildkite"
-PIPELINE=$( nix-instantiate "$NIX_EXPR" | nix run 'github:hackworthltd/nix-buildkite-plugin?ref=v1.1.2#nix-buildkite' )
+if [[ -n "${BUILDKITE_PLUGIN_NIX_NIX_EVAL_JOBS_ARGS:-}" ]]; then
+    export NIX_EVAL_JOBS_ARGS="$BUILDKITE_PLUGIN_NIX_NIX_EVAL_JOBS_ARGS"
+fi
+
+if [[ -n "${BUILDKITE_PLUGIN_NIX_JQ_OPTS:-}" ]]; then
+    export JQ_OPTS="$BUILDKITE_PLUGIN_NIX_JQ_OPTS"
+fi
+
+if [[ -n "${BUILDKITE_PLUGIN_NIX_JQ_FILTER:-}" ]]; then
+    export JQ_FILTER="$BUILDKITE_PLUGIN_NIX_JQ_FILTER"
+fi
+
+echo "--- :nixos: Running nix-buildkite with nix-eval-jobs"
+PIPELINE=$( nix run 'github:hackworthltd/nix-buildkite-plugin?ref=v2.0.0-b1#with-nix-eval-jobs' -- "$NIX_EXPR" )
 
 echo "--- :pipeline: Uploading pipeline"
 echo "$PIPELINE" | buildkite-agent pipeline upload

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,6 +6,12 @@ configuration:
     properties:
         expr:
             type: string
+        nix-eval-jobs-args:
+            type: string
+        jq-opts:
+            type: string
+        jq-filter:
+            type: string
         post-build-hook:
             type: string
         agent-tags:
@@ -14,6 +20,9 @@ configuration:
         - expr
     not:
         required:
+            - nix-eval-jobs-args
+            - jq-opts
+            - jq-filter
             - post-build-hook
             - agent-tags
     additionalProperties: false

--- a/scripts/with-nix-eval-jobs.sh
+++ b/scripts/with-nix-eval-jobs.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <expr>" >&2
+  exit 1
+fi
+
+: "${NIX_EVAL_JOBS_ARGS:=}"
+: "${JQ_OPTS:=-re}"
+: "${JQ_FILTER:=try (.drvPath) catch halt_error}"
+
+read -r -a nix_eval_job_args <<< "$NIX_EVAL_JOBS_ARGS"
+read -r -a jq_opts <<< "$JQ_OPTS"
+
+nix-eval-jobs "$1" "${nix_eval_job_args[@]}" | jq "${jq_opts[@]}" "$JQ_FILTER" | nix-buildkite


### PR DESCRIPTION
In this commit, we switch to `nix-eval-jobs`:

https://github.com/nix-community/nix-eval-jobs

The plugin takes new options:

* `nix-eval-jobs-args` to set the arguments to `nix-eval-jobs` (default is empty).

* `jq-opts` to set the arguments to `jq`, which is used to parse the JSON output of `nix-eval-jobs` (default is `-re`).

* `jq-filter`: to set the `jq` filter (default is `try (.drvPath) catch halt_error`). The output of the filter should be a list of Nix derivations to build.