### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump-nix-deps.yaml
+++ b/.github/workflows/bump-nix-deps.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: Update Nix dependencies.
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/hackworthltd/nix-buildkite-plugin/security/code-scanning/1](https://github.com/hackworthltd/nix-buildkite-plugin/security/code-scanning/1)

To fix the problem, add a `permissions:` key at the top level of the workflow, just after the `name:` and before `on:`, specifying the least necessary privileges. For most workflows, a starting minimal set is `contents: read` unless write access (such as for PRs, issues, or other resources) is necessary. Since the workflow reuses another workflow, it's advisable to consult the requirements of the called workflow (`reusable-update-nix-flake-public.yml`). If you know exactly what scopes it needs to write to (for example, to update dependencies and submit a pull-request), you should grant only those scopes. As a minimal and safe starting point per CodeQL guidance (and since updating dependencies often involves creating a PR), use:

```yaml
permissions:
  contents: read
  pull-requests: write
```

This should be added at the workflow root, between `name:` and `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
