### PR TITLE
feat!: when using Kubernetes plugin, apply it to all steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Note that this option is ignored when `use-nix-build` is `true`.
 
 ## `kubernetes-pod-template`
 
-When `kubernetes-pod-template` is set, then when the plugin generates the dynamic Buildkite pipeline, it will use the [Buildkite Kubernetes plugin](https://github.com/buildkite/agent-stack-k8s) on every step in the pipeline that builds a Linux derivation/attribute, and provide the value of this option to the Kubernetes plugin. For example, given the following use of the `nix-buildkite` pipeline:
+When `kubernetes-pod-template` is set, then when the plugin generates the dynamic Buildkite pipeline, it will use the [Buildkite Kubernetes plugin](https://github.com/buildkite/agent-stack-k8s) on every step in the pipeline, and provide the value of this option to the Kubernetes plugin. For example, given the following use of the `nix-buildkite` pipeline:
 
 ```yaml
 steps:
@@ -164,7 +164,7 @@ steps:
           kubernetes-pod-template: nix-rootless
 ```
 
-then every step in the resulting pipeline that builds a Linux attribute will include the following stanza:
+then every step in the resulting pipeline will include the following stanza:
 
 ```yaml
 plugins:

--- a/exe-nix-buildkite/Main.hs
+++ b/exe-nix-buildkite/Main.hs
@@ -185,7 +185,6 @@ main = do
                 ]
 
               -- Optionally add the agent-stack-k8s kubernetes plugin
-              -- for Linux steps
               kubernetesPluginFields =
                 [ "plugins"
                     .= Array
@@ -198,8 +197,7 @@ main = do
                               ]
                           ]
                       )
-                | isLinuxSystem (Map.lookup drvPath drvSystemMap)
-                , Just tpl' <- [kubernetesPodTemplate]
+                | Just tpl' <- [kubernetesPodTemplate]
                 , let tpl = T.strip tpl'
                 , not (T.null tpl)
                 ]
@@ -207,10 +205,6 @@ main = do
               isDarwinSystem :: Maybe Text -> Bool
               isDarwinSystem (Just system) = "darwin" `T.isSuffixOf` system
               isDarwinSystem Nothing = False
-
-              isLinuxSystem :: Maybe Text -> Bool
-              isLinuxSystem (Just system) = "linux" `T.isSuffixOf` system
-              isLinuxSystem Nothing = False
 
           buildCommand :: Text -> Text
           buildCommand drvPath =


### PR DESCRIPTION
Note that this assumes the specified pod template creates a pod that's capable of building any Nix `system` generated by the pipeline, via remote builders if necessary, for systems that can't run Kubernetes.